### PR TITLE
Add merklemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ If you want a list of resources rather than tools, you should check out [this](h
  - [Moriarty](https://github.com/AzizKpln/Moriarty-Project) - Collects information from phone numbers
  - [GHunt](https://github.com/mxrch/GHunt) - GHunt is an OSINT tool to extract a lot of informations of someone's Google Account email.
  - [Spyse](https://spyse.com/) - OSINT gathering platform that collects valuable data and stores it in its own database to provide info without scanning. Info clusters: IPv4 hosts, domains/whois/site info, ports/banners/protocols, technologies, maintain biggest SSL/TLS db, AS, OS etc...
+ - [Merklemap](https://www.merklemap.com/) A subdomain search engine.
 ### Username Checkers
  - [Check Usernames](http://checkusernames.com/)
  - [No Name Username Scanner](https://inteltechniques.com/osint/menu.user.html)


### PR DESCRIPTION
This PR adds https://www.merklemap.com/ which is a subdomain search engine.